### PR TITLE
Meta: update group and URLs after move to WICG

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,10 +2,9 @@
 Title: Web Speech API
 Level:
 Status: CG-DRAFT
-Status Text: All feedback is welcome: public-speech-api@w3.org (<a href="https://lists.w3.org/Archives/Public/public-speech-api/">Public archive</a>).
-Group: SACG
-URL: https://w3c.github.io/speech-api/
-Repository: w3c/speech-api
+Group: WICG
+URL: https://wicg.github.io/speech-api/
+Repository: WICG/speech-api
 Shortname: speech-api
 Editor: André Natal (Mozilla)
 Editor: Glen Shires (Google)


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/speech-api/pull/75.html" title="Last updated on Jan 20, 2020, 7:43 AM UTC (cc4fa41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/speech-api/75/3e6582c...cc4fa41.html" title="Last updated on Jan 20, 2020, 7:43 AM UTC (cc4fa41)">Diff</a>