### PR TITLE
chore: Use Python 3 for Travis, not Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ branches:
     - master
 language: python
 python:
-  - "2.7"
+  - "3.8"
 install:
   - git clone https://github.com/tabatkins/bikeshed.git
-  - pip install --editable bikeshed
+  - pip3 install --editable bikeshed
   - bikeshed update
 script:
   - bikeshed spec


### PR DESCRIPTION
Bikeshed now requires Python 3