### PR TITLE
chore: Disambiguate {{charIndex}} link to silence Bikeshed warning

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -777,7 +777,7 @@ These events bubble up to SpeechSynthesis.
 
   <dt><dfn attribute for=SpeechSynthesisEvent>charLength</dfn> attribute</dt>
   <dd>This attribute indicates the length of the text (word or sentence) that will be spoken corresponding to this event.
-  This attribute is the length, in characters, starting from this event's {{charIndex}}.
+  This attribute is the length, in characters, starting from this event's {{SpeechSynthesisEvent/charIndex}}.
   The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return 0.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisEvent>elapsedTime</dfn> attribute</dt>


### PR DESCRIPTION
The warning was:

LINK ERROR: Multiple possible 'idl' local refs for 'charIndex'.
Randomly chose one of them; other instances might get a different random choice.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/speech-api/pull/79.html" title="Last updated on Jun 30, 2020, 10:45 AM UTC (f9eab14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/speech-api/79/b97a050...f9eab14.html" title="Last updated on Jun 30, 2020, 10:45 AM UTC (f9eab14)">Diff</a>