### PR TITLE
Format editor metadata correctly

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,10 +6,10 @@ Group: WICG
 URL: https://wicg.github.io/speech-api/
 Repository: WICG/speech-api
 Shortname: speech-api
-Editor: André Natal (Mozilla)
-Editor: Glen Shires (Google)
-Editor: Philip Jägenstedt (Google)
-Former Editor: Hans Wennborg (Google)
+Editor: André Natal, Mozilla
+Editor: Glen Shires, Google
+Editor: Philip Jägenstedt, Google
+Former Editor: Hans Wennborg, Google
 !Tests: <a href=https://github.com/web-platform-tests/wpt/tree/master/speech-api>web-platform-tests speech-api/</a> (<a href=https://github.com/web-platform-tests/wpt/labels/speech-api>ongoing work</a>)
 Abstract: This specification defines a JavaScript API to enable web developers to incorporate speech recognition and synthesis into their web pages.
 Abstract: It enables developers to use scripting to generate text-to-speech output and to use speech recognition as an input for forms, continuous dictation and control.


### PR DESCRIPTION
According to https://tabatkins.github.io/bikeshed/#metadata-editor, it's comma-separated, not ()ed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/speech-api/pull/94.html" title="Last updated on May 11, 2021, 9:46 PM UTC (5a33669)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/speech-api/94/a099053...jyasskin:5a33669.html" title="Last updated on May 11, 2021, 9:46 PM UTC (5a33669)">Diff</a>